### PR TITLE
Update __init__.py

### DIFF
--- a/pylhe/__init__.py
+++ b/pylhe/__init__.py
@@ -29,7 +29,7 @@ class LHEParticle(object):
     def __init__(self, **kwargs):
         if not set(kwargs.keys()) == set(self.fieldnames):
             raise RuntimeError
-        for k,v in kwargs.iteritems():
+        for k,v in kwargs.items():
             setattr(self,k,v)
     
     @classmethod


### PR DESCRIPTION
Line 19 should read "for k,v in kwargs.items():" rather than "for k,v in kwargs.iteritems():" in order to be compatible with Python 3. See the answer to [this stack exchange question.](https://stackoverflow.com/questions/8899129/how-do-i-loop-through-kwargs-in-python)